### PR TITLE
Feat/channel live moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "description": "Abstract Puppet for Wechaty",
   "type": "module",
   "exports": {

--- a/src/schemas/channel.ts
+++ b/src/schemas/channel.ts
@@ -9,8 +9,7 @@ export interface ChannelPayload {
   url: string,
 
   /**
-   * The following two fields are required when posting Channel Live moment.
-   * However sending Channel Live message without such fields is fine.
+   * The following two fields are required for Live Channel only.
    */
   objectId?: string,
   objectNonceId?: string,

--- a/src/schemas/channel.ts
+++ b/src/schemas/channel.ts
@@ -7,4 +7,11 @@ export interface ChannelPayload {
   nickname: string,
   thumbUrl: string,
   url: string,
+
+  /**
+   * The following two fields are required when posting Channel Live moment.
+   * However sending Channel Live message without such fields is fine.
+   */
+  objectId?: string,
+  objectNonceId?: string,
 }


### PR DESCRIPTION
经测试，  objectId, objectNonceId 这两个字段不传不会影响接收方，但会导致发送方显示异常（朋友圈只显示图片，消息固定显示直播中）