### PR TITLE
fix: use computed key for memberId in roomMember cache write

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet",
-  "version": "1.0.135",
+  "version": "1.0.136",
   "description": "Abstract Puppet for Wechaty",
   "type": "module",
   "exports": {

--- a/src/mixins/room-member-mixin.ts
+++ b/src/mixins/room-member-mixin.ts
@@ -179,7 +179,7 @@ const roomMemberMixin = <MixinBase extends typeof PuppetSkeleton & ContactMixin>
       if (!this.cache.disabled) {
         this.cache.roomMember!.set(roomId, {
           ...cachedPayload,
-          memberId: payload,
+          [memberId]: payload,
         })
         log.silly('PuppetRoomMemberMixin', 'roomMemberPayload(%s) cache SET', roomId)
       }

--- a/tests/room-member-cache.spec.ts
+++ b/tests/room-member-cache.spec.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env -S node --no-warnings --loader ts-node/esm
+
+import { test }  from 'tstest'
+
+import { PuppetTest } from './fixtures/puppet-test/puppet-test.js'
+
+/**
+ * Regression test for `roomMemberPayload` cache key write bug.
+ *
+ * Before the fix, line 182 wrote `memberId: payload` (a literal property
+ * named 'memberId') instead of `[memberId]: payload` (a computed key using
+ * the variable's value). Because the read path uses `cachedPayload[memberId]`,
+ * the cache hit rate was always 0 — every call fell back to raw RPC.
+ *
+ * See: src/mixins/room-member-mixin.ts (the `set` call inside
+ * `roomMemberPayload`).
+ */
+test('roomMemberPayload cache hit (uses computed key for memberId)', async t => {
+  const puppet = new PuppetTest()
+  await puppet.start()
+  t.teardown(() => puppet.stop())
+
+  const roomId   = 'room-1'
+  const memberId = 'member-1'
+
+  let rawCalls = 0
+  const originalRaw = puppet.roomMemberRawPayload.bind(puppet)
+  puppet.roomMemberRawPayload = async (rid: string, mid: string) => {
+    rawCalls++
+    return originalRaw(rid, mid)
+  }
+
+  // First call: cache miss → raw is invoked once.
+  await puppet.roomMemberPayload(roomId, memberId)
+  t.equal(rawCalls, 1, 'first call: cache miss, raw payload invoked once')
+
+  // Second call with the same (roomId, memberId): should hit cache.
+  // Before the fix, the cache write used a literal key 'memberId' so this
+  // hit would miss and raw would be invoked again (rawCalls would become 2).
+  await puppet.roomMemberPayload(roomId, memberId)
+  t.equal(rawCalls, 1, 'second call: cache hit, raw NOT invoked again')
+
+  // Verify the cache stores the entry under the computed memberId key,
+  // not under the literal 'memberId' string.
+  const cached = (puppet as any).cache.roomMember?.get(roomId)
+  t.ok(cached, 'cache slot for roomId is populated')
+  t.ok(cached[memberId], 'payload is stored under the actual memberId key')
+  // When the fix is applied, the computed-key write means the literal
+  // string 'memberId' is never used as a property — the only own key on
+  // `cached` should be the actual memberId value.
+  t.notOk(
+    Object.prototype.hasOwnProperty.call(cached, 'memberId'),
+    'no stray "memberId" literal key (would be present if computed-key bug regressed)',
+  )
+})
+
+test('roomMemberPayload accumulates multiple members under the same room', async t => {
+  const puppet = new PuppetTest()
+  await puppet.start()
+  t.teardown(() => puppet.stop())
+
+  const roomId = 'room-2'
+
+  await puppet.roomMemberPayload(roomId, 'm-a')
+  await puppet.roomMemberPayload(roomId, 'm-b')
+  await puppet.roomMemberPayload(roomId, 'm-c')
+
+  const cached = (puppet as any).cache.roomMember?.get(roomId)
+  t.ok(cached, 'cache slot exists')
+  t.ok(cached['m-a'], 'm-a is cached under its own key')
+  t.ok(cached['m-b'], 'm-b is cached under its own key')
+  t.ok(cached['m-c'], 'm-c is cached under its own key')
+})


### PR DESCRIPTION
## Bug

`roomMemberPayload` writes the cache value as:

```ts
this.cache.roomMember!.set(roomId, {
  ...cachedPayload,
  memberId: payload,   // ← literal property name 'memberId'
})
```

The read path uses `cachedPayload[memberId]` (computed access using the variable's value).

**Result**: the write goes to a property literally named `'memberId'`, but reads look up the actual member ID — every read misses, the cache hit rate is effectively **0%**, and every `roomMemberPayload(roomId, memberId)` falls through to `roomMemberRawPayload`.

## Impact

For multi-bot deployments servicing many rooms with high group-membership query traffic (e.g. message handlers that resolve sender info per message), this causes:

- Unnecessary RPC traffic to the underlying puppet implementation (puppet-service / puppet-rabbit etc.) on every membership lookup.
- Repeated `roomMemberRawPayloadParser` work.
- Larger heap pressure from repeated payload allocations.

Discovered during a memory-treatment pass on a 22-bot deployment where group-membership queries dominated RPC traffic.

## Fix

One-character change — use a computed property key so `memberId`'s value becomes the property name:

```diff
-          memberId: payload,
+          [memberId]: payload,
```

## Verification

Added `tests/room-member-cache.spec.ts` with two regression checks:

1. **Cache hit**: second call with the same `(roomId, memberId)` must hit cache; raw payload is invoked exactly once, not twice.
2. **Multi-member accumulation**: multiple members under the same room each cache under their own key.

The new test:
- ❌ **fails** on the buggy code (verified by stash + re-run before fix)
- ✅ **passes** after the fix

`npx tsc --isolatedModules --noEmit` passes clean.

Full `tap "src/**/*.spec.ts" "tests/**/*.spec.ts"` passes — all 28 specs (27 existing + 1 new).

## Scope

Audited all 21 mixins in `src/mixins/` for the same anti-pattern. This is the **only occurrence**: every other `this.cache.X.set(id, payload)` writes the whole payload directly as the value, so there's no chance for variable-as-literal-key shadowing.

No changes to public API. No behavioral changes other than the cache actually being populated correctly.