### PR TITLE
feat: add messageVoice / messageVoiceText abstract methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet",
-  "version": "1.0.141",
+  "version": "1.0.142",
   "description": "Abstract Puppet for Wechaty",
   "type": "module",
   "exports": {

--- a/src/mixins/message-mixin.ts
+++ b/src/mixins/message-mixin.ts
@@ -30,6 +30,9 @@ import type {
   LocationPayload,
 }                                 from '../schemas/location.js'
 import type {
+  VoiceTextPayload,
+}                                 from '../schemas/voice.js'
+import type {
   PostPayload,
 }                                 from '../schemas/post.js'
 
@@ -88,6 +91,28 @@ const messageMixin = <MinxinBase extends typeof PuppetSkeleton & CacheMixin>(bas
     abstract messageContact                       (messageId: string)                       : Promise<string>
     abstract messageFile                          (messageId: string)                       : Promise<FileBoxInterface>
     abstract messageImage                         (messageId: string, imageType: ImageType) : Promise<FileBoxInterface>
+    /**
+     * Second-request accessor for a voice message's audio file.
+     *
+     * Sibling of messageImage/messageFile: the message is synced first, the
+     * voice file (e.g. a `.silk` FileBox) is fetched on demand here.
+     *
+     * Implementations that do not support voice second-request should
+     * `throw throwUnsupportedError()` (see other puppet implementations' convention).
+     */
+    abstract messageVoice                         (messageId: string)                       : Promise<FileBoxInterface>
+    /**
+     * Second-request accessor for a voice message's ASR (voice-to-text) result.
+     *
+     * Returns a discriminated payload `{ text, noSpeech }` rather than a bare
+     * string: `noSpeech = true` means the puppet ASR confirmed the voice has no
+     * valid speech (e.g. WeCom EMPTY_VOICE_TEXT_2070), so the bot can skip its
+     * own paid ASR; otherwise `text` carries the transcription.
+     *
+     * Implementations that do not support voice second-request should
+     * `throw throwUnsupportedError()` (see other puppet implementations' convention).
+     */
+    abstract messageVoiceText                     (messageId: string)                       : Promise<VoiceTextPayload>
     abstract messageMiniProgram                   (messageId: string)                       : Promise<MiniProgramPayload>
     abstract messageUrl                           (messageId: string)                       : Promise<UrlLinkPayload>
     abstract messageLocation                      (messageId: string)                       : Promise<LocationPayload>

--- a/src/schemas/mod.ts
+++ b/src/schemas/mod.ts
@@ -110,6 +110,9 @@ import type {
 import type {
   LocationPayload,
 }                             from './location.js'
+import type {
+  VoiceTextPayload,
+}                             from './voice.js'
 
 import type {
   PuppetOptions,
@@ -331,6 +334,7 @@ export {
   type CallMediaEndpointPayload,
   type CallPayload,
   type CallRecordPayload,
+  type VoiceTextPayload,
   type EventCallPayload,
   type ChatHistoryPayload,
   type ContactIdExternalUserIdPair,

--- a/src/schemas/voice.ts
+++ b/src/schemas/voice.ts
@@ -1,0 +1,5 @@
+export interface VoiceTextPayload {
+  text     : string,   // the ASR (voice-to-text) result; empty string when no valid speech
+  noSpeech : boolean,  // true when the puppet ASR confirmed the voice has no valid speech
+                       // (e.g. WeCom EMPTY_VOICE_TEXT_2070), so the bot can skip its own paid ASR
+}


### PR DESCRIPTION
## What

Add two abstract puppet methods, symmetric to `messageImage` / `messageFile`:

- `messageVoice(id): Promise<FileBoxInterface>` — voice file as a second request
- `messageVoiceText(id): Promise<VoiceTextPayload>` — `{ text, noSpeech }`

New `VoiceTextPayload` schema (`src/schemas/voice.ts`).

## Why

Decouples voice-to-text (ASR) from the synchronous `messagePayload`, aligning voice with the other rich-media "sync message first, fetch data later" model. `noSpeech` lets consumers skip a redundant **paid** ASR call when the platform already confirmed the clip has no speech.

## Scope / compat

Pure additive at the interface layer. Abstract per the Call/Image convention — concrete puppets implement (or `throwUnsupportedError`) when they bump this dependency. Version: `1.0.141 → 1.0.142`.

Part of a multi-repo change: wechaty-puppet → wechaty-grpc → wechaty-puppet-service → wechaty → xiaoju-bot-nested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCmXBqNF3QhpbLnQJTqgR2
